### PR TITLE
fix: compaction race condition causing crash and enable Datadog in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@
 #   AWS_SECRET_ACCESS_KEY
 
 # Build stage
-FROM rust:1.83-slim-bookworm AS builder
+FROM rust:1.85-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \
@@ -42,14 +42,14 @@ RUN mkdir -p src/bin && \
     echo "fn main() {}" > src/bin/server_optimized.rs && \
     echo "fn main() {}" > src/bin/server_persistent.rs && \
     echo "" > src/lib.rs && \
-    cargo build --release --features s3 2>/dev/null || true && \
+    cargo build --release --features "s3,datadog" 2>/dev/null || true && \
     rm -rf src target/release/.fingerprint/redis-sim-* \
            target/release/server-persistent target/release/redis-server-optimized \
            target/release/deps/redis_sim-* target/release/deps/libredis_sim* \
            target/release/incremental/redis_sim-*
 
 COPY src ./src
-RUN cargo build --release --features s3 \
+RUN cargo build --release --features "s3,datadog" \
     --bin redis-server-optimized \
     --bin server-persistent
 


### PR DESCRIPTION
## Summary

Fixes two issues discovered when running the persistent server under load:

1. **Compaction crash: "I/O error: No such file or directory"**
   - Root cause: Race condition between persistence actor and compaction worker
   - Both used separate `ManifestManager` instances without coordination
   - Persistence would overwrite manifest with stale segment references after compaction deleted old files
   - Next compaction would try to read already-deleted segment files

2. **Datadog logs not being pushed**
   - Root cause: `datadog` feature was not enabled in the main `Dockerfile`
   - Also required Rust 1.85+ due to dependency updates (edition 2024)

## Changes

- **`src/streaming/compaction.rs`**: Handle missing segment files gracefully
  - Skip missing segments with warning instead of crashing
  - Clean stale segment references from manifest
  - Track actually processed segments separately from originally selected

- **`src/streaming/persistence.rs`**: Reload manifest before allocating segment IDs
  - Prevents segment ID collisions when compaction has allocated new IDs
  - Small I/O overhead per flush, but ensures correctness

- **`docker/Dockerfile`**:
  - Enable `datadog` feature in cargo build
  - Upgrade to Rust 1.85 (required for updated dependencies)

## Test plan

- [x] Docker build succeeds with `docker build -t redis-sesh -f docker/Dockerfile .`
- [x] Run persistent server under load - no more compaction crashes
- [x] Verify Datadog metrics/traces appear when agent is configured



  Test Results Summary

  | Test Suite | Result |
  |------------|--------|
  | Unit Tests (lib) | ✅ 124 passed |
  | Anti-Entropy Tests | ✅ 8 passed |
  | Causal Consistency Tests | ✅ 10 passed |
  | Connection Simulation Tests | ✅ 10 passed |
  | CRDT DST Tests | ✅ 15 passed, 1 ignored |
  | DST Batch Verification | ✅ 5 passed |
  | Eventual Consistency Tests | ✅ 9 passed |
  | Metrics Tests | ✅ 26 passed |
  | Skewed Workload Tests | ✅ 5 passed |
  | Streaming DST Tests | ✅ 11 passed, 2 ignored |
  | Streaming Persistence Tests | ✅ 9 passed |
  | Redis Equivalence Tests | 11 ignored (requires real Redis) |
  Total: 232 tests passed, 0 failed ✅